### PR TITLE
Add an enabled parameter that completely removes postfix if set to false

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -20,9 +20,14 @@
 # This class is called from postfix
 #
 class postfix::config {
+  $ensure = $postfix::enabled ? {
+    true => file,
+    false => absent
+  }
+
   file {
     '/etc/postfix/main.cf':
-      ensure  => file,
+      ensure  => $ensure,
       content => template('postfix/etc/postfix/main.cf.erb'),
       mode    => '0644',
       owner   => root,
@@ -30,11 +35,14 @@ class postfix::config {
       notify  => Service['postfix'];
 
     '/etc/aliases':
-      ensure  => file,
+      ensure  => $ensure,
       content => template('postfix/etc/aliases.erb'),
       mode    => '0644',
       owner   => root,
       group   => root,
-      notify  => Exec['postalias'];
+      notify  => $postfix::enabled ? {
+        true => Exec['postalias'],
+        false => []
+      };
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,7 +43,8 @@ class postfix(
   $root_email                   = $postfix::params::root_email,
   $relayhosts                   = undef,
   $extranetwork                 = undef,
-  $myorigin                     = $postfix::params::myorigin
+  $myorigin                     = $postfix::params::myorigin,
+  $enabled                      = $postfix::params::enabled
 ) inherits postfix::params {
 
   contain postfix::install

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -24,11 +24,17 @@ class postfix::install {
 
   package {
     $packagelist:
-      ensure => installed;
+      ensure => $postfix::enabled ? {
+        true => installed,
+        false => absent
+      }
   }
 
   package {
     'mailutils':
-      ensure => latest;
+      ensure => $postfix::enabled ? {
+        true => latest,
+        false => absent
+      }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,4 +24,6 @@ class postfix::params {
   $root_email = 'localhost'
 
   $myorigin = $::realfqdn
+
+  $enabled = true
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -24,12 +24,18 @@
 class postfix::service {
 
   service { 'postfix':
-    ensure => running,
-    enable => true;
+    ensure => $postfix::enabled ? {
+      true => running,
+      false => stopped
+    },
+    enable => $postfix::enabled;
   }
 
-  exec { 'postalias':
-    command     => '/usr/sbin/postalias /etc/aliases',
-    refreshonly => true;
+  if $postfix::enabled {
+    exec { 'postalias':
+      command     => '/usr/sbin/postalias /etc/aliases',
+      refreshonly => true;
+    }
   }
+
 }


### PR DESCRIPTION
Fixes skyscrapers/inventive-designers#223

It turns out that some hosts had run this module in the past, but once it was disabled from puppet, postfix and all its configuration files remained installed on those servers. So if postfix is disabled on a host, it should be completely wiped out.
