### PR TITLE
add optional smtp relay authentication

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -45,4 +45,24 @@ class postfix::config inherits ::postfix {
         false => []
       };
   }
+
+
+  if $postfix::gmail_smtp_relay_enabled {
+    file { "/etc/postfix/sasl/sasl_passwd":
+      ensure => file,
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0600',
+      content => template('postfix/etc/postfix/sasl/sasl_passwd/sasl_passwd.erb'),
+    }
+    exec { 'create_hash_db':
+      user    => 'root',
+      path    => '/usr/bin:/usr/sbin:/bin/:/sbin',
+      command => 'postmap /etc/postfix/sasl/sasl_passwd && chmod 0600 /etc/postfix/sasl/sasl_passwd.db && service postfix reload',
+      creates => '/etc/icinga2/postgres_module_loaded.txt',
+      subscribe => File['/etc/postfix/sasl/sasl_passwd'],
+      refresh_only => true,
+    }
+  }
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,7 +38,18 @@
 #       relayhosts    => ['[mail01.example.com]','[mail02.example.com]:2525'],
 #       myorigin      => 'server.example.com'
 #     }
+# * Installation of postfix with smtp relay authentication
+#     class {'postfix':
+#       root_email               => 'email@example.com',
+#       relayhosts               => ['[mail01.example.com]','[mail02.example.com]:2525'],
+#       myorigin                 => 'server.example.com'
+#       smtp_relay_auth_enabled  => true
+#       smtp_relay_auth_email    => user@example.com
+#       smtp_relay_auth_password => secret_password
 #
+#     }
+#
+
 class postfix(
   $root_email                   = $postfix::params::root_email,
   $relayhosts                   = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,10 @@ class postfix(
   $extranetwork                 = undef,
   $myorigin                     = $postfix::params::myorigin,
   $enabled                      = $postfix::params::enabled
+  $smtp_relay_auth_enabled      = false,
+  $smtp_relay_auth_email        = undef,
+  $smtp_relay_auth_password     = undef,
+
 ) inherits postfix::params {
 
   contain postfix::install

--- a/templates/etc/postfix/main.cf.erb
+++ b/templates/etc/postfix/main.cf.erb
@@ -45,3 +45,14 @@ mailbox_size_limit = 0
 recipient_delimiter = +
 inet_interfaces = all
 inet_protocols = ipv4
+
+<% if @smtp_relay_auth_enabled -%>
+# Enable SASL authentication
+smtp_sasl_auth_enable = yes
+# Disallow methods that allow anonymous authentication
+smtp_sasl_security_options = noanonymous
+# Location of sasl_passwd
+smtp_sasl_password_maps = hash:/etc/postfix/sasl/sasl_passwd
+# Enable STARTTLS encryption
+smtp_tls_security_level = encrypt
+

--- a/templates/etc/postfix/sasl/sasl_passwd
+++ b/templates/etc/postfix/sasl/sasl_passwd
@@ -1,0 +1,7 @@
+<% if @smtp_relay_auth_enabled -%>
+<% if @relayhosts -%>
+<% @relayhosts.each do |relayhost| -%>
+<%= relayhost %> <%= smtp_relay_auth_email %>:<%= smtp_relay_auth_password %>
+<% end -%>
+<% end -%>
+<% end -%>


### PR DESCRIPTION
adds configuration needed for smtp relay authentication, disabled by default

related issue: https://github.com/skyscrapers/puppet/issues/4484